### PR TITLE
Use unified ServiceNow PID directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ agentic_solutions/
 ├── create_final_servicenow_specs.py     # OpenAPI spec generator
 ├── cleanup_junk.py                      # Cleanup utility
 ├── openapi_specs/                       # Generated OpenAPI specifications
-├── .pids/                              # Process ID files
+├── .servicenow_pids/                   # Process ID files
 └── .env                                # ServiceNow credentials (not in repo)
 ```
 

--- a/start_servicenow_http_system.py
+++ b/start_servicenow_http_system.py
@@ -10,10 +10,11 @@ import time
 import pathlib
 import requests
 
-PID_DIR = pathlib.Path(".pids")
+PID_DIR = pathlib.Path(".servicenow_pids")
 TABLE_SERVER_PID_FILE = PID_DIR / "table_server.pid"
 KNOWLEDGE_SERVER_PID_FILE = PID_DIR / "knowledge_server.pid"
 MAGENTIC_UI_PID_FILE = PID_DIR / "magentic_ui.pid"
+
 
 def get_pid(pid_file):
     if pid_file.exists():
@@ -23,6 +24,7 @@ def get_pid(pid_file):
             return None
     return None
 
+
 def is_process_running(pid):
     if pid is None:
         return False
@@ -31,6 +33,7 @@ def is_process_running(pid):
         return True
     except OSError:
         return False
+
 
 def stop_service(name, pid_file, process_name_grep):
     print(f"🛑 Stopping {name}...")
@@ -48,21 +51,32 @@ def stop_service(name, pid_file, process_name_grep):
             print(f"❌ Error stopping {name} (PID: {pid}): {e}")
     else:
         print(f"   {name} not running or PID file missing.")
-    
+
     # Also kill any lingering processes by name
     try:
-        subprocess.run(["pkill", "-f", process_name_grep], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        subprocess.run(
+            ["pkill", "-f", process_name_grep],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
         time.sleep(1)
     except subprocess.CalledProcessError:
         pass  # Process not found, no big deal
-    
+
     if pid_file.exists():
         pid_file.unlink()
+
 
 def start_service(name, cmd, pid_file):
     print(f"📊 Starting {name}...")
     try:
-        process = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, preexec_fn=os.setsid)
+        process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            preexec_fn=os.setsid,
+        )
         pid_file.write_text(str(process.pid))
         print(f"✅ {name} started successfully (PID: {process.pid})")
         return process.pid
@@ -70,12 +84,14 @@ def start_service(name, cmd, pid_file):
         print(f"❌ Failed to start {name}: {e}")
         return None
 
+
 def check_health(url):
     try:
         response = requests.get(url, timeout=5)
         return response.status_code == 200
     except requests.exceptions.RequestException:
         return False
+
 
 def main():
     print("🚀 ServiceNow MCP System - HTTP Transport Startup")
@@ -101,28 +117,62 @@ def main():
 
     # Stop existing services
     stop_service("Magentic-UI", MAGENTIC_UI_PID_FILE, "magentic-ui")
-    stop_service("ServiceNow Table API Server", TABLE_SERVER_PID_FILE, "servicenow_table_http_server.py")
-    stop_service("ServiceNow Knowledge API Server", KNOWLEDGE_SERVER_PID_FILE, "servicenow_knowledge_http_server.py")
+    stop_service(
+        "ServiceNow Table API Server",
+        TABLE_SERVER_PID_FILE,
+        "servicenow_table_http_server.py",
+    )
+    stop_service(
+        "ServiceNow Knowledge API Server",
+        KNOWLEDGE_SERVER_PID_FILE,
+        "servicenow_knowledge_http_server.py",
+    )
 
     # Start HTTP MCP servers as separate processes
-    table_pid = start_service("ServiceNow Table API Server", [".venv/bin/python", "servicenow_table_http_server.py"], TABLE_SERVER_PID_FILE)
-    knowledge_pid = start_service("ServiceNow Knowledge API Server", [".venv/bin/python", "servicenow_knowledge_http_server.py"], KNOWLEDGE_SERVER_PID_FILE)
-    
+    table_pid = start_service(
+        "ServiceNow Table API Server",
+        [".venv/bin/python", "servicenow_table_http_server.py"],
+        TABLE_SERVER_PID_FILE,
+    )
+    knowledge_pid = start_service(
+        "ServiceNow Knowledge API Server",
+        [".venv/bin/python", "servicenow_knowledge_http_server.py"],
+        KNOWLEDGE_SERVER_PID_FILE,
+    )
+
     print("⏳ Waiting for MCP servers to initialize...")
     time.sleep(5)
-    
-    magentic_ui_pid = start_service("Magentic-UI", [".venv/bin/magentic-ui", "--host", "localhost", "--port", "8090", "--config", "servicenow_final_config.yaml"], MAGENTIC_UI_PID_FILE)
+
+    magentic_ui_pid = start_service(
+        "Magentic-UI",
+        [
+            ".venv/bin/magentic-ui",
+            "--host",
+            "localhost",
+            "--port",
+            "8090",
+            "--config",
+            "servicenow_final_config.yaml",
+        ],
+        MAGENTIC_UI_PID_FILE,
+    )
 
     print("\n📊 Service Status:")
     print("========================================")
-    
+
     table_running = is_process_running(table_pid)
     knowledge_running = is_process_running(knowledge_pid)
     magentic_ui_running = is_process_running(magentic_ui_pid)
 
-    print(f"✅ Table API Server: {'Running' if table_running else 'Stopped'} (PID: {table_pid}) - http://localhost:3001")
-    print(f"✅ Knowledge API Server: {'Running' if knowledge_running else 'Stopped'} (PID: {knowledge_pid}) - http://localhost:3002")
-    print(f"✅ Magentic-UI: {'Running' if magentic_ui_running else 'Stopped'} (PID: {magentic_ui_pid}) - http://localhost:8090")
+    print(
+        f"✅ Table API Server: {'Running' if table_running else 'Stopped'} (PID: {table_pid}) - http://localhost:3001"
+    )
+    print(
+        f"✅ Knowledge API Server: {'Running' if knowledge_running else 'Stopped'} (PID: {knowledge_pid}) - http://localhost:3002"
+    )
+    print(
+        f"✅ Magentic-UI: {'Running' if magentic_ui_running else 'Stopped'} (PID: {magentic_ui_pid}) - http://localhost:8090"
+    )
 
     if table_running and knowledge_running and magentic_ui_running:
         print("\n🎉 All services started successfully!")
@@ -131,10 +181,13 @@ def main():
         print("   • servicenow_table_agent (Table API)")
         print("   • servicenow_knowledge_agent (Knowledge Management)")
         print("   • Plus default agents: web_surfer, coder_agent, file_surfer")
-        print("\n💡 Use '.venv/bin/python stop_servicenow_system.py' to stop all services")
+        print(
+            "\n💡 Use '.venv/bin/python stop_servicenow_system.py' to stop all services"
+        )
         print("💡 HTTP MCP servers running independently - more reliable!")
     else:
         print("\n⚠️  Some services failed to start. Check logs for details.")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Store HTTP system PIDs in `.servicenow_pids` to match other ServiceNow scripts.
- Document `.servicenow_pids/` as the canonical PID storage location.

## Testing
- `uv run pytest`
- `uv run python start_servicenow_http_system.py`
- `uv run python status_servicenow_system.py`
- `uv run python stop_servicenow_system.py` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'lsof')*
- `apt-get install -y lsof` *(fails: Unable to locate package lsof)*

------
https://chatgpt.com/codex/tasks/task_e_68919a556a48832b9186d9826a5d6cec