### PR TITLE
Avoid port conflicts between Tempo and otel-collector

### DIFF
--- a/observability/docker-compose.observability.yml
+++ b/observability/docker-compose.observability.yml
@@ -68,8 +68,7 @@ services:
     image: grafana/tempo:latest
     ports:
       - "3200:3200"   # Tempo HTTP
-      - "4317:4317"   # OTLP gRPC (shared with otel-collector)
-      - "4318:4318"   # OTLP HTTP (shared with otel-collector)
+      # OTLP gRPC (4317) and HTTP (4318) not mapped to host to avoid conflicts with otel-collector
     volumes:
       - ./tempo.yaml:/etc/tempo.yaml:ro
       - tempo_data:/tmp/tempo


### PR DESCRIPTION
## Summary
- remove Tempo's 4317/4318 host port mappings to avoid OTLP conflicts with otel-collector
- note in compose file that OTLP ports are internal only

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pyroscope')*
- `docker compose -f observability/docker-compose.observability.yml down` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689347b5a91c832bba39ab4d75150795